### PR TITLE
Bump terraform-aws-vpc-peering version to 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ module "kops_vpc_peering" {
   stage                                            = "dev"
   name                                             = "cluster"
   backing_services_vpc_id                          = "vpc-XXXXXXXX"
-  dns_zone                                         = "cluster.domain.com"
+  dns_zone                                         = "us-west-2.domain.com"
   bastion_name                                     = "bastion"
   masters_name                                     = "masters"
   nodes_name                                       = "nodes"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ __NOTE:__ The backing services VPC must have subnets associated with route table
 
 __NOTE:__ When enabled, the DNS resolution feature (`backing_services_allow_remote_vpc_dns_resolution`)
 require that the backing services VPC must have support for the DNS hostnames enabled.
+
 This can be done using the [`enable_dns_hostnames`](https://www.terraform.io/docs/providers/aws/r/vpc.html#enable_dns_hostnames) attribute in the `aws_vpc` resource.
 
 https://www.terraform.io/docs/providers/aws/r/vpc_peering.html#allow_remote_vpc_dns_resolution

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "kops_metadata" {
 
 # Create a peering connection between the backing services VPC and Kops VPC
 module "vpc_peering" {
-  source                                    = "git::https://github.com/cloudposse/terraform-aws-vpc-peering.git?ref=tags/0.1.0"
+  source                                    = "git::https://github.com/cloudposse/terraform-aws-vpc-peering.git?ref=tags/0.1.1"
   enabled                                   = "${var.enabled}"
   namespace                                 = "${var.namespace}"
   name                                      = "${var.name}"


### PR DESCRIPTION
## what
* Bump `terraform-aws-vpc-peering` version to `0.1.1`

## why
* Fix eventual consistency issues
* `terraform-aws-vpc-peering` module could not find the Route it just created in the same session

```
* aws_route.requestor: 1 error(s) occurred:

* aws_route.requestor: Error finding route after creating it: 

Unable to find matching route for Route Table (rtb-f40f0c93) and destination CIDR block (10.0.0.0/16).
```